### PR TITLE
added endpoint to return buildings in given floor

### DIFF
--- a/building_server/lib/building_server_web/controllers/building_controller.ex
+++ b/building_server/lib/building_server_web/controllers/building_controller.ex
@@ -1,9 +1,20 @@
 defmodule BuildingServerWeb.BuildingController do
   use BuildingServerWeb, :controller
-  alias BuildingServer.{Repo, Building}
+  alias BuildingServer.Repo
+  import Ecto.Query, only: [from: 2]
 
   def index(conn, _params) do
-    buildings = Repo.all(Building)
+    query = from bldg in "buildings",
+              where: bldg.x >= 0
+    buildings = Repo.all(query)
     render conn, "index.json", buildings: buildings
   end
+
+  def buildings_in_address(conn, %{"address" => address}) do
+    query = from bldg in "buildings",
+              where: bldg.flr == ^address
+    buildings = Repo.all(query)
+    render conn, "index.json", buildings: buildings
+  end
+
 end

--- a/building_server/lib/building_server_web/controllers/building_controller.ex
+++ b/building_server/lib/building_server_web/controllers/building_controller.ex
@@ -7,21 +7,21 @@ defmodule BuildingServerWeb.BuildingController do
     query = from bldg in "buildings",
               where: bldg.x >= 0
     buildings = Repo.all(query)
-    render conn, "index.json", buildings: buildings
+    render conn, "buildings.json", buildings: buildings
   end
 
   def get_building(conn, %{"address" => address}) do
     query = from bldg in "buildings",
               where: bldg.address == ^address
     buildings = Repo.all(query)
-    render conn, "index.json", buildings: buildings
+    render conn, "buildings.json", buildings: buildings
   end
 
   def get_buildings_in_address(conn, %{"address" => address}) do
     query = from bldg in "buildings",
               where: bldg.flr == ^address
     buildings = Repo.all(query)
-    render conn, "index.json", buildings: buildings
+    render conn, "buildings.json", buildings: buildings
   end
 
 end

--- a/building_server/lib/building_server_web/controllers/building_controller.ex
+++ b/building_server/lib/building_server_web/controllers/building_controller.ex
@@ -10,7 +10,14 @@ defmodule BuildingServerWeb.BuildingController do
     render conn, "index.json", buildings: buildings
   end
 
-  def buildings_in_address(conn, %{"address" => address}) do
+  def get_building(conn, %{"address" => address}) do
+    query = from bldg in "buildings",
+              where: bldg.address == ^address
+    buildings = Repo.all(query)
+    render conn, "index.json", buildings: buildings
+  end
+
+  def get_buildings_in_address(conn, %{"address" => address}) do
     query = from bldg in "buildings",
               where: bldg.flr == ^address
     buildings = Repo.all(query)

--- a/building_server/lib/building_server_web/router.ex
+++ b/building_server/lib/building_server_web/router.ex
@@ -23,5 +23,7 @@ defmodule BuildingServerWeb.Router do
      pipe_through :api
 
      get "/buildings", BuildingController, :index
+     get "/buildings/in/:address", BuildingController, :buildings_in_address
+
   end
 end

--- a/building_server/lib/building_server_web/router.ex
+++ b/building_server/lib/building_server_web/router.ex
@@ -23,7 +23,8 @@ defmodule BuildingServerWeb.Router do
      pipe_through :api
 
      get "/buildings", BuildingController, :index
-     get "/buildings/in/:address", BuildingController, :buildings_in_address
+     get "/buildings/:address", BuildingController, :get_building
+     get "/buildings/in/:address", BuildingController, :get_buildings_in_address
 
   end
 end

--- a/building_server/lib/building_server_web/views/building_view.ex
+++ b/building_server/lib/building_server_web/views/building_view.ex
@@ -3,7 +3,8 @@ defmodule BuildingServerWeb.BuildingView do
 
   def render("index.json", %{buildings: buildings}) do
     %{
-      buildings: Enum.map(buildings, &building_json/1)
+      count: Enum.count(buildings),
+      buildings: buildings
     }
   end
 

--- a/building_server/lib/building_server_web/views/building_view.ex
+++ b/building_server/lib/building_server_web/views/building_view.ex
@@ -1,11 +1,8 @@
 defmodule BuildingServerWeb.BuildingView do
   use BuildingServerWeb, :view
 
-  def render("index.json", %{buildings: buildings}) do
-    %{
-      count: Enum.count(buildings),
-      buildings: buildings
-    }
+  def render("buildings.json", %{buildings: buildings}) do
+    buildings
   end
 
   def building_json(building) do


### PR DESCRIPTION
## Why
Allow clients to get all buildings directly within a given floor

## What
Added endpoint `/api/buildings/in/:address`

## Notes
* `Repo.all(Building)` and `Repo.all(query)` seem to have a different return type - the 1st required a transformation into dicts. As a work-around, I'm now using only `Repo.all(query)`